### PR TITLE
fix: commit-msg hook failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -e $GIT_PARAMS",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-commit": "lint-staged"
     }
   },


### PR DESCRIPTION
https://github.com/marionebl/commitlint/issues/366
node v8.9.4
git version 2.8.1.windows.1
windows 10.0.17134
未在其他环境验证
```
husky > pre-commit (node v8.9.4)
Running tasks for *.{es,js} [started]
eslint [started]
eslint [completed]
Running tasks for *.{es,js} [completed]
husky > commit-msg (node v8.9.4)
Using environment variable syntax ($GIT_PARAMS) in -e |--edit is deprecated. Use '{-E|--env} GIT_PARAMS instead'
A:\*************\plugin-quest\node_modules\commitlint\node_modules\@commitlint\cli\lib\cli.js:103
        throw err;
        ^

Error: Received $GIT_PARAMS as value for -e | --edit, but GIT_PARAMS is not available globally.
    at getEditValue (A:\*************\plugin-quest\node_modules\commitlint\node_modules\@commitlint\cli\lib\cli.js:226:10)
    at normalizeFlags (A:\*************\plugin-quest\node_modules\commitlint\node_modules\@commitlint\cli\lib\cli.js:197:15)
    at A:\*************\plugin-quest\node_modules\commitlint\node_modules\@commitlint\cli\lib\cli.js:110:11
    at new Promise (<anonymous>)
    at main (A:\*************\plugin-quest\node_modules\commitlint\node_modules\@commitlint\cli\lib\cli.js:107:9)
    at Object.<anonymous> (A:\*************\plugin-quest\node_modules\commitlint\node_modules\@commitlint\cli\lib\cli.js:99:1)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
husky > commit-msg hook failed (add --no-verify to bypass)
```