### PR TITLE
fix: disable keySeparator in reward translations

### DIFF
--- a/index.es
+++ b/index.es
@@ -110,7 +110,7 @@ QuestItem.propTypes = {
 
 const RewardItem = withTranslation(NS, { nsMode: 'fallback' })(
   ({ t, reward }) => {
-    let name = t(reward.name)
+    let name = t(reward.name, { keySeparator: false })
     if (reward.category) {
       name = t('「') + name + t('」')
     }


### PR DESCRIPTION
https://media.discordapp.net/attachments/561775550692327435/753725609577938967/unknown.png for F78.

Names with dots are not being translated, so I'm setting `keySeparator` to `false`, not sure why it is required, since plugin-translator already does that, but this fixes it.